### PR TITLE
Modify move-to-workspace-up script to allow for smooth transitions

### DIFF
--- a/dot_config/niri/scripts/executable_dynamic-move-to-workspace-up.sh
+++ b/dot_config/niri/scripts/executable_dynamic-move-to-workspace-up.sh
@@ -20,6 +20,7 @@ if [ "$focused_idx" -ne 1 ]; then
 else
   last_workspace_idx=$(echo "$workspaces_state" | jq --arg output "$focused_output" '.[] | select(.output == $output) | .idx' | sort -n | tail -n 1)
 
-  niri msg action move-window-to-workspace "$last_workspace_idx"
-  niri msg action move-workspace-to-index 1
+  niri msg action move-window-to-workspace --focus false "$last_workspace_idx"
+  niri msg action move-workspace-to-index --reference "$last_workspace_idx" 1
+  niri msg action focus-workspace-up
 fi


### PR DESCRIPTION
I was looking for the functionality of moving a workspace up if you're on the first workspace and I came across your post in the Niri discussions, but I found a way to improve it.

The previous implementation moved the current window to the last workspace, then moved that workspace to be the first. This worked but caused the animations to break.

The change in this commit moves the window to the last workspace in the background (Without focusing it), moves that workspace to be the first and then focuses it, making it look like any other Niri transition.